### PR TITLE
fix: do not write header for gtf file

### DIFF
--- a/scRNAsim_toolz/structure_generator/main.py
+++ b/scRNAsim_toolz/structure_generator/main.py
@@ -166,18 +166,6 @@ def write_gtf(gtf_df: pd.DataFrame, filename: str) -> None:
     )
 
 
-def write_header(annotations_file: str) -> None:
-    """Write the header of an annotations file.
-
-    It consists of the tab delimited column names.
-
-    Args:
-        annotations_file: Filename to write header to.
-    """
-    with open(annotations_file, "w", encoding="utf_8") as file_header:
-        file_header.write("\t".join(Gtf.dtypes.keys()) + "\n")
-
-
 class Gtf:
     """Class to read transcripts annotations file into a Gtf object.
 
@@ -515,8 +503,6 @@ def sample_transcripts(
     LOG.info("Done parsing...")
 
     LOG.info("Start sampling transcripts...")
-    # Set up output file, write header once and append data in loop
-    write_header(output_annotations_file)
 
     for _, row in transcripts.iterrows():
         transcript_id = row["id"]


### PR DESCRIPTION
removed gtf file header from structure generator, as gtf files aren't supposed to have headers and this caused errors in downstream processes.

Closes #5 